### PR TITLE
prevent Directory does not exist error

### DIFF
--- a/pi-apps-terminal-bash-edition.sh
+++ b/pi-apps-terminal-bash-edition.sh
@@ -209,7 +209,7 @@ while [[ "$1" != "" ]]; do
 				IFS=$'\n'
 				for folder in "$DIRECTORY"/apps/*; do
 					if [[ "$app" == "$(basename "${folder,,}")" ]]; then
-						app="$folder"
+						app="${folder##*/}"
 						match=true
 						break
 					fi

--- a/pi-apps-terminal-bash-edition.sh
+++ b/pi-apps-terminal-bash-edition.sh
@@ -209,7 +209,7 @@ while [[ "$1" != "" ]]; do
 				IFS=$'\n'
 				for folder in "$DIRECTORY"/apps/*; do
 					if [[ "$app" == "$(basename "${folder,,}")" ]]; then
-						app="${folder##*/}"
+						app="$(basename "$folder")"
 						match=true
 						break
 					fi


### PR DESCRIPTION
running `./pi-apps-terminal-bash-edition.sh install color emoji font` results in the following error: 
```
/home/pi/pi-apps/apps//home/pi/pi-apps/apps/Color Emoji font does not exist!
```

to fix, you can simply remove everything before `/` and the app will be installed correctly.